### PR TITLE
[FIX] 금융 API 예외 처리 코드 수정

### DIFF
--- a/src/main/java/com/fav/daengnyang/domain/member/service/dto/MemberService.java
+++ b/src/main/java/com/fav/daengnyang/domain/member/service/dto/MemberService.java
@@ -7,7 +7,6 @@ import com.fav.daengnyang.domain.member.service.dto.request.AccountCreationHeade
 import com.fav.daengnyang.domain.member.service.dto.request.CreatedRequest;
 import com.fav.daengnyang.domain.member.service.dto.request.MemberBankRequest;
 import com.fav.daengnyang.domain.member.service.dto.response.AccountCreationResponse;
-import com.fav.daengnyang.domain.member.service.dto.response.MemberBankResponse;
 import com.fav.daengnyang.domain.member.service.dto.response.LoginResponse;
 import com.fav.daengnyang.global.auth.dto.MemberAuthority;
 import com.fav.daengnyang.global.auth.utils.JWTProvider;
@@ -89,16 +88,11 @@ public class MemberService {
 
         // 4. 외부 API 호출
         String url = "/member";
+
         ResponseEntity<String> response = restTemplate.postForEntity(url, requestEntity, String.class);
 
-        // 5. 외부 API 응답 처리
-        if (response.getStatusCode().is2xxSuccessful()) {
             log.info("회원 가입 API 결과: " + response.getBody());
             return objectMapper.readValue(response.getBody(), MemberBankRequest.class);
-        } else {
-            // 응답 상태가 2xx가 아닌 경우, 오류 처리
-            throw new RuntimeException("API 호출 오류: " + response.getBody());
-        }
     }
 
     // 계좌 생성 API
@@ -126,12 +120,7 @@ public class MemberService {
         ResponseEntity<String> response = restTemplate.postForEntity(url, requestEntity, String.class);
 
         // 5. 외부 API 응답 처리
-        if (response.getStatusCode().is2xxSuccessful()) {
-            log.info("계좌 생성 API 결과: " + response.getBody());
-            return objectMapper.readValue(response.getBody(), AccountCreationResponse.class).getAccountNo();
-        } else {
-            // 응답 상태가 2xx가 아닌 경우, 오류 처리
-            throw new RuntimeException("API 호출 오류: " + response.getBody());
-        }
+        log.info("계좌 생성 API 결과: " + response.getBody());
+        return objectMapper.readValue(response.getBody(), AccountCreationResponse.class).getAccountNo();
     }
 }

--- a/src/main/java/com/fav/daengnyang/global/handler/ApiExceptionHandler.java
+++ b/src/main/java/com/fav/daengnyang/global/handler/ApiExceptionHandler.java
@@ -7,6 +7,7 @@ import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fav.daengnyang.global.dto.response.ExceptionResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.ConversionNotSupportedException;
@@ -15,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.stereotype.Repository;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
@@ -136,5 +139,17 @@ public class ApiExceptionHandler {
         return ResponseEntity
                 .status(BAD_REQUEST)
                 .body(buildResponse(BAD_REQUEST, exception));
+    }
+
+    // 금융 API 호출 시 해당 API에서 발생하는 예외를 처리
+    @ExceptionHandler(HttpClientErrorException.class)
+    public ResponseEntity<ExceptionResponse> handleHttpClientErrorException(HttpClientErrorException exception) {
+        HttpStatus status = (HttpStatus) exception.getStatusCode();
+
+        return ResponseEntity.status(status)
+                .body(ExceptionResponse.builder()
+                        .status(status.value())
+                        .message(exception.getResponseBodyAsString())
+                        .build());
     }
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #21 

### 📝 작업 내용
- ApiExceptionHandler 에 HttpClientErrorException 예외 처리 코드 구현
- MemberService 코드 수정

![image](https://github.com/user-attachments/assets/4f085b03-efc5-4e9d-8e76-95ffa3d68616)


### 📝 남은 작업
- 신한 API에서 받은 에러 코드와 메시지를 그대로 프론트 단으로 보내기 때문에 메시지 부분에 대해 나중에 논의가 필요할 것 같습니다.
