### PR TITLE
[FEAT] 저축 목표 목록 가져오기

### DIFF
--- a/src/main/java/com/fav/daengnyang/domain/target/controller/TargetController.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/controller/TargetController.java
@@ -1,0 +1,28 @@
+package com.fav.daengnyang.domain.target.controller;
+
+import com.fav.daengnyang.domain.target.service.dto.TargetService;
+import com.fav.daengnyang.domain.target.service.dto.response.TargetResponse;
+import com.fav.daengnyang.global.web.dto.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/targets")
+@RestController
+public class TargetController {
+
+    private final TargetService targetService;
+
+    // 유저의 모든 목표 리스트로 조회하기
+    @GetMapping
+    public SuccessResponse<List<TargetResponse>> getTargets(@RequestParam(value = "memberId") Long memberId){
+
+        List<TargetResponse> targets = targetService.findTargets(memberId);
+        return SuccessResponse.ok(targets);
+    }
+}

--- a/src/main/java/com/fav/daengnyang/domain/target/entity/Target.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/entity/Target.java
@@ -1,0 +1,40 @@
+package com.fav.daengnyang.domain.target.entity;
+
+import com.fav.daengnyang.domain.bankbook.entity.Bankbook;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class Target {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long targetId;
+
+    private String description;
+    private int targetAmount;
+    private String targetTitle;
+    private int currentAmount;
+    private boolean isDone;
+
+    @ManyToOne(fetch = FetchType.LAZY) // Bankbook과의 다대일 관계
+    @JoinColumn(name = "bankbook_id") // 외래 키: bankbook_id
+    private Bankbook bankbook; // Target이 속한 Bankbook 객체
+
+    @Builder
+    public Target(Long targetId, String description, int targetAmount, String targetTitle, int currentAmount, boolean isDone, Bankbook bankbook) {
+        this.targetId = targetId;
+        this.description = description;
+        this.targetAmount = targetAmount;
+        this.targetTitle = targetTitle;
+        this.currentAmount = currentAmount;
+        this.isDone = isDone;
+        this.bankbook = bankbook;
+    }
+}

--- a/src/main/java/com/fav/daengnyang/domain/target/repository/TargetRepository.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/repository/TargetRepository.java
@@ -1,0 +1,17 @@
+package com.fav.daengnyang.domain.target.repository;
+
+import com.fav.daengnyang.domain.target.entity.Target;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TargetRepository extends JpaRepository<Target, Long> {
+
+    // 특정 memberId를 가진 Bankbook의 모든 Target을 조회하는 JPQL 쿼리
+    @Query("SELECT t FROM Target t JOIN t.bankbook b WHERE b.member.memberId = :memberId")
+    List<Target> findAllByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/fav/daengnyang/domain/target/service/dto/TargetService.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/dto/TargetService.java
@@ -1,0 +1,38 @@
+package com.fav.daengnyang.domain.target.service.dto;
+
+import com.fav.daengnyang.domain.target.entity.Target;
+import com.fav.daengnyang.domain.target.repository.TargetRepository;
+import com.fav.daengnyang.domain.target.service.dto.response.TargetResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TargetService {
+
+    private final TargetRepository targetRepository;
+
+    // 유저의 모든 목표 조회 메소드
+    public List<TargetResponse> findTargets(Long memberId) {
+
+        // memberId로 Target 리스트 조회
+        List<Target> targets = targetRepository.findAllByMemberId(memberId);
+
+        // Target 리스트를 TargetResponse 리스트로 변환하여 반환
+        return targets.stream()
+                .map(target -> TargetResponse.builder()
+                        .targetId(target.getTargetId())
+                        .description(target.getDescription())
+                        .targetAmount(target.getTargetAmount())
+                        .targetTitle(target.getTargetTitle())
+                        .currentAmount(target.getCurrentAmount())
+                        .isDone(target.isDone())
+                        .bankbookId(target.getBankbook().getBankbookId())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/fav/daengnyang/domain/target/service/dto/request/dummy.txt
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/dto/request/dummy.txt
@@ -1,0 +1,1 @@
+this is dummy file.

--- a/src/main/java/com/fav/daengnyang/domain/target/service/dto/request/dummy.txt
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/dto/request/dummy.txt
@@ -1,1 +1,0 @@
-this is dummy file.

--- a/src/main/java/com/fav/daengnyang/domain/target/service/dto/response/TargetResponse.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/dto/response/TargetResponse.java
@@ -1,0 +1,30 @@
+package com.fav.daengnyang.domain.target.service.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class TargetResponse {
+    private Long targetId;
+    private String description;
+    private int targetAmount;
+    private String targetTitle;
+    private int currentAmount;
+    private Boolean isDone;
+    private Long bankbookId;
+
+    @Builder
+    public TargetResponse (Long targetId, String description, int targetAmount, String targetTitle, int currentAmount, Boolean isDone, Long bankbookId) {
+        this.targetId = targetId;
+        this.description = description;
+        this.targetAmount = targetAmount;
+        this.targetTitle = targetTitle;
+        this.currentAmount = currentAmount;
+        this.isDone = isDone;
+        this.bankbookId = bankbookId;
+    }
+}


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #16 

### 📝 작업 내용
- 유저의 모든 저축 목표 목록 리스트 가져오기
- ![image (2)](https://github.com/user-attachments/assets/fd9e5099-55a9-40e6-97a8-84921d472a77)


### 📝 리뷰 요청사항
- `Target`에는 유저의 `id`가 없기 때문에 유저 id를 통해 `Bankbook id`를 알아내고, 그것을 통해 해당하는 `Target`들을 필터링 해야 합니다.
- 그래서 처음에는 유저의 `Bankbook`이 없을 경우를 생각해서 에러 처리를 하려고 했는데, 쿼리 동작 중에 에러가 나는 상황이라서 쿼리를 쓰지 않고 각각의 과정을 `TargetService` 에서 직접 하려고 했습니다.
- 그랬더니 `MemberRepository`와 `BankbookRepository` 를 `TargetService` 에서 사용해야 하더라구요. 누가봐도 결합도가 너무 높아지는 상황이라서 다른 방법을 찾던 중에
- 어차피 `Target`을 만들려면 유저는 `Bankbook`을 무조건적으로 만들어야 하고, 즉 해당 API를 호출할 때 유저가 `Bankbook`이 없을 경우는 없다
- 라는 씽크빅한 생각이 나왔습니다.
- 그래서 일단 따로 에러 처리를 하지 않고 올렸습니다. (`target` 이 없는 경우는 에러가 아니라 빈 리스트를 반환하도록 했습니다.)
- 다만 어떤 오류로 인해 `Bankbook`만 삭제되는 경우 (정상적인 경우라면 일어나진 않을 것 같습니다) 에는 해당 예외 처리가 필요할 것 같은데... 
- 이런 경우레는 어떻게 해야 좋을지 의견을 묻고 싶습니다!
