### PR TITLE
[FEAT] 모든 목표 요약 정보 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	// Lombok in tests
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// Jackson module (for using 'LocalDateTime')
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/fav/daengnyang/domain/bankbook/entity/Bankbook.java
+++ b/src/main/java/com/fav/daengnyang/domain/bankbook/entity/Bankbook.java
@@ -1,6 +1,6 @@
 package com.fav.daengnyang.domain.bankbook.entity;
 
-import com.fav.daengnyang.domain.bookdata.entity.BankbookDetail;
+import com.fav.daengnyang.domain.bookdata.entity.BookdataDetail;
 import com.fav.daengnyang.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -29,5 +29,5 @@ public class Bankbook {
     private Member member;
 
     @OneToMany(mappedBy = "bankbook", cascade = CascadeType.ALL)
-    private List<BankbookDetail> bankbookDetails;  // 'mappedBy' 속성을 'bankbook'으로 설정
+    private List<BookdataDetail> bookdataDetails;  // 'mappedBy' 속성을 'bankbook'으로 설정
 }

--- a/src/main/java/com/fav/daengnyang/domain/bookdata/entity/BookdataDetail.java
+++ b/src/main/java/com/fav/daengnyang/domain/bookdata/entity/BookdataDetail.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 @NoArgsConstructor
-public class BankbookDetail {
+public class BookdataDetail {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/fav/daengnyang/domain/bookdata/repository/BookdataRepository.java
+++ b/src/main/java/com/fav/daengnyang/domain/bookdata/repository/BookdataRepository.java
@@ -1,17 +1,17 @@
 package com.fav.daengnyang.domain.bookdata.repository;
 
-import com.fav.daengnyang.domain.bookdata.entity.BankbookDetail;
+import com.fav.daengnyang.domain.bookdata.entity.BookdataDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface BankbookDetailRepository extends JpaRepository<BankbookDetail, Long> {
+public interface BookdataRepository extends JpaRepository<BookdataDetail, Long> {
 
-    @Query("SELECT SUM(bd.amount) FROM BankbookDetail bd WHERE bd.bankbook.id = :bankbookId")
+    @Query("SELECT SUM(bd.amount) FROM BookdataDetail bd WHERE bd.bankbook.id = :bankbookId")
     Integer findTotalAmountByBankbookId(@Param("bankbookId") Long bankbookId);
 
-    @Query("SELECT COUNT(bd) FROM BankbookDetail bd WHERE bd.bankbook.id = :bankbookId")
+    @Query("SELECT COUNT(bd) FROM BookdataDetail bd WHERE bd.bankbook.id = :bankbookId")
     Long countTransactionsByBankbookId(@Param("bankbookId") Long bankbookId);
 }

--- a/src/main/java/com/fav/daengnyang/domain/bookdata/service/BookdataService.java
+++ b/src/main/java/com/fav/daengnyang/domain/bookdata/service/BookdataService.java
@@ -2,7 +2,7 @@ package com.fav.daengnyang.domain.bookdata.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fav.daengnyang.domain.bookdata.repository.BankbookDetailRepository;
+import com.fav.daengnyang.domain.bookdata.repository.BookdataRepository;
 import com.fav.daengnyang.domain.bookdata.service.dto.response.BookdataSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +22,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class BookdataService {
 
-    private final BankbookDetailRepository bankbookDetailRepository;
+    private final BookdataRepository bookdataRepository;
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
 
@@ -31,8 +31,8 @@ public class BookdataService {
 
     // Bookdata 요약 정보 가져오기 메서드
     public BookdataSummaryResponse getBookdataSummary(Long bankbookId, String accountNo) throws JsonProcessingException {
-        Integer totalAmount = bankbookDetailRepository.findTotalAmountByBankbookId(bankbookId);
-        Long transactionCount = bankbookDetailRepository.countTransactionsByBankbookId(bankbookId);
+        Integer totalAmount = bookdataRepository.findTotalAmountByBankbookId(bankbookId);
+        Long transactionCount = bookdataRepository.countTransactionsByBankbookId(bankbookId);
 
         // 금융 API 호출 예시
         Map<String, Object> balanceResponse = callInquireAccountBalanceApi(accountNo);

--- a/src/main/java/com/fav/daengnyang/domain/target/controller/TargetController.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/controller/TargetController.java
@@ -1,12 +1,16 @@
 package com.fav.daengnyang.domain.target.controller;
 
-import com.fav.daengnyang.domain.target.service.dto.TargetService;
+import com.fav.daengnyang.domain.target.service.TargetService;
+import com.fav.daengnyang.domain.target.service.TargetSummaryService;
 import com.fav.daengnyang.domain.target.service.dto.request.CreateTargetRequest;
 import com.fav.daengnyang.domain.target.service.dto.response.TargetResponse;
+import com.fav.daengnyang.domain.target.service.dto.response.TargetSummaryResponse;
+import com.fav.daengnyang.global.auth.dto.MemberPrincipal;
 import com.fav.daengnyang.global.web.dto.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,6 +21,7 @@ import java.util.List;
 public class TargetController {
 
     private final TargetService targetService;
+    private final TargetSummaryService targetSummaryService;
 
     // 목표 등록
     // 성공, 실패 여부만 return
@@ -38,4 +43,16 @@ public class TargetController {
         List<TargetResponse> targets = targetService.findTargets(memberId);
         return SuccessResponse.ok(targets);
     }
+
+    // 지금까지의 덕질 정보 가져오기
+    @GetMapping("/summary")
+    public SuccessResponse<?> getTargetSummary(@AuthenticationPrincipal MemberPrincipal memberPrincipal){
+        Long memberId = memberPrincipal.getMemberId();
+
+        // service 호출
+        TargetSummaryResponse summary = targetSummaryService.getTargetSummary(memberId);
+
+        return SuccessResponse.ok(summary);
+    }
+
 }

--- a/src/main/java/com/fav/daengnyang/domain/target/entity/BankbookDetail.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/entity/BankbookDetail.java
@@ -1,0 +1,37 @@
+package com.fav.daengnyang.domain.target.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+public class BankbookDetail {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long detailId;
+
+    private int amount;
+
+    private LocalDate createdDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id")
+    private Target target;
+
+    @Builder
+    public BankbookDetail(Long detailId, int amount, LocalDate createdDate, Target target) {
+        this.detailId = detailId;
+        this.amount = amount;
+        this.createdDate = createdDate;
+        this.target = target;
+    }
+
+}

--- a/src/main/java/com/fav/daengnyang/domain/target/repository/BankbookDetailRepository.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/repository/BankbookDetailRepository.java
@@ -1,0 +1,17 @@
+package com.fav.daengnyang.domain.target.repository;
+
+import com.fav.daengnyang.domain.target.entity.BankbookDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface BankbookDetailRepository extends JpaRepository<BankbookDetail, Long> {
+
+    // 특정 memberId에 해당하는 모든 BankbookDetail 조회
+    @Query("SELECT bd FROM BankbookDetail bd JOIN bd.target t JOIN t.bankbook b WHERE b.member.memberId = :memberId")
+    List<BankbookDetail> findByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/fav/daengnyang/domain/target/service/TargetService.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/TargetService.java
@@ -1,4 +1,4 @@
-package com.fav.daengnyang.domain.target.service.dto;
+package com.fav.daengnyang.domain.target.service;
 
 import com.fav.daengnyang.domain.bankbook.entity.Bankbook;
 import com.fav.daengnyang.domain.bankbook.repository.BankbookRepository;
@@ -63,4 +63,6 @@ public class TargetService {
                         .build())
                 .toList();
     }
+
+
 }

--- a/src/main/java/com/fav/daengnyang/domain/target/service/TargetSummaryService.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/TargetSummaryService.java
@@ -1,0 +1,67 @@
+package com.fav.daengnyang.domain.target.service;
+
+import com.fav.daengnyang.domain.target.entity.BankbookDetail;
+import com.fav.daengnyang.domain.target.entity.Target;
+import com.fav.daengnyang.domain.target.repository.BankbookDetailRepository;
+import com.fav.daengnyang.domain.target.repository.TargetRepository;
+import com.fav.daengnyang.domain.target.service.dto.response.AchievedTargetInfoResponse;
+import com.fav.daengnyang.domain.target.service.dto.response.TargetSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TargetSummaryService {
+
+    private final BankbookDetailRepository bankbookDetailRepository;
+    private final TargetRepository targetRepository;
+
+    // 전체 목표 요약 메소드
+    public TargetSummaryResponse getTargetSummary(Long memberId) {
+        // 유저의 모든 BankbookDetail 조회
+        List<BankbookDetail> bankbookDetails = bankbookDetailRepository.findByMemberId(memberId);
+
+        // 통계 값 계산
+        int totalDeposits = bankbookDetails.size();
+        int totalAmount = bankbookDetails.stream().mapToInt(BankbookDetail::getAmount).sum();
+
+        // 달성한 목표 정보 계산
+        List<Target> targets = targetRepository.findAllByMemberId(memberId);
+        int achievedTargetsCount = 0;
+        List<AchievedTargetInfoResponse> achievedTargets = new ArrayList<>();
+
+        for (Target target : targets) {
+            if(target.isDone()){
+                achievedTargetsCount++;
+                AchievedTargetInfoResponse achievedTargetInfoResponse = AchievedTargetInfoResponse.builder()
+                        .targetTitle(target.getTargetTitle())
+                        .targetAmount(target.getTargetAmount())
+                        .completedDate(bankbookDetails.stream()
+                                .filter(detail -> detail.getTarget().equals(target))
+                                .map(BankbookDetail::getCreatedDate)
+                                .max(LocalDate::compareTo) // 가장 최근의 날짜를 선택
+                                .orElse(null))
+                        .build();
+                achievedTargets.add(achievedTargetInfoResponse);
+            }
+        }
+
+        // 평균 계산
+        double averageDepositsPerTargets = targets.isEmpty() ? 0 : (double) totalDeposits / targets.size();
+        double averageAmountPerDeposit = totalDeposits == 0 ? 0 : (double) totalAmount / totalDeposits;
+
+        // 결과 반환
+        return TargetSummaryResponse.builder()
+                .averageDepositsPerTarget(averageDepositsPerTargets)
+                .averageAmountPerDeposit(averageAmountPerDeposit)
+                .achievedTargetsCount(achievedTargetsCount)
+                .achievedTargets(achievedTargets)
+                .build();
+    }
+}

--- a/src/main/java/com/fav/daengnyang/domain/target/service/dto/response/AchievedTargetInfoResponse.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/dto/response/AchievedTargetInfoResponse.java
@@ -1,0 +1,25 @@
+package com.fav.daengnyang.domain.target.service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class AchievedTargetInfoResponse {
+    private String targetTitle;
+    private int targetAmount;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate completedDate;
+
+    @Builder
+    public AchievedTargetInfoResponse(String targetTitle, int targetAmount, LocalDate completedDate) {
+        this.targetTitle = targetTitle;
+        this.targetAmount = targetAmount;
+        this.completedDate = completedDate;
+    }
+}

--- a/src/main/java/com/fav/daengnyang/domain/target/service/dto/response/TargetSummaryResponse.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/dto/response/TargetSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.fav.daengnyang.domain.target.service.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor
+@Getter
+public class TargetSummaryResponse {
+    private double averageDepositsPerTarget;
+    private double averageAmountPerDeposit;
+    private int achievedTargetsCount;
+    private List<AchievedTargetInfoResponse> achievedTargets;
+
+    @Builder
+    public TargetSummaryResponse(double averageDepositsPerTarget, double averageAmountPerDeposit, int achievedTargetsCount, List<AchievedTargetInfoResponse> achievedTargets) {
+        this.averageDepositsPerTarget = averageDepositsPerTarget;
+        this.averageAmountPerDeposit = averageAmountPerDeposit;
+        this.achievedTargetsCount = achievedTargetsCount;
+        this.achievedTargets = achievedTargets;
+    }
+}

--- a/src/main/java/com/fav/daengnyang/global/config/WebConfig.java
+++ b/src/main/java/com/fav/daengnyang/global/config/WebConfig.java
@@ -1,6 +1,8 @@
 package com.fav.daengnyang.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,9 +17,15 @@ public class WebConfig {
                 .build();
     }
 
+
     @Bean
     public ObjectMapper objectMapper(){
-        return new ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper();
+        // JavaTimeModule을 등록하여 LocalDate 등의 직렬화/역직렬화 지원
+        mapper.registerModule(new JavaTimeModule());
+        // 타임스탬프로 날짜를 쓰지 않도록 설정 (ISO 8601 형식 사용)
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
     }
 
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #46 

### 📝 작업 내용
- 목표 요약 정보 조회
- Bookdata 부분의 이름 겹치는 파일들 수정
- Jackson 시간 포맷 설정 추가
- 결과 화면
    - ![image](https://github.com/user-attachments/assets/64e7b152-a90c-4b68-9cc7-e23687398b1b)


### 📝 리뷰 요청사항
- API 명세서의 '지금까지 덕질한 정보 조회' 라는 네이밍이 맞지 않는 것 같아서 '목표 요약 정보 조회' 라는 이름으로 바꾸려고 하는데, 괜찮을까요?
