### PR TITLE
[FEAT] 목표 삭제

### DIFF
--- a/src/main/java/com/fav/daengnyang/domain/target/controller/TargetController.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/controller/TargetController.java
@@ -73,6 +73,16 @@ public class TargetController {
         return SuccessResponse.ok("이체가 성공적으로 완료되었습니다.");
     }
 
+    // 저축 목표에 대한 저축내역 가져오기
+    @GetMapping("/{targetId}")
+    public SuccessResponse<List<TargetDetailResponse>> getTargetDetails(
+            @PathVariable Long targetId){
+        //service 호출
+        List<TargetDetailResponse> targetDetails = targetService.getTargetDetails(targetId);
+        return SuccessResponse.ok(targetDetails);
+
+    }
+
     // 목표 삭제하기
     @DeleteMapping("/{targetId}")
     public SuccessResponse<String> deleteTarget(
@@ -83,15 +93,7 @@ public class TargetController {
         targetService.deleteTarget(memberPrincipal.getMemberId(), targetId, memberPrincipal.getUserKey());
 
         return SuccessResponse.ok("목표가 성공적으로 삭제되었습니다.");
-
-      
-    // 저축 목표에 대한 저축내역 가져오기
-    @GetMapping("/{targetId}")
-    public SuccessResponse<List<TargetDetailResponse>> getTargetDetails(
-            @PathVariable Long targetId){
-        //service 호출
-        List<TargetDetailResponse> targetDetails = targetService.getTargetDetails(targetId);
-        return SuccessResponse.ok(targetDetails);
-
     }
+      
+
 }

--- a/src/main/java/com/fav/daengnyang/domain/target/controller/TargetController.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/controller/TargetController.java
@@ -72,4 +72,16 @@ public class TargetController {
 
         return SuccessResponse.ok("이체가 성공적으로 완료되었습니다.");
     }
+
+    // 목표 삭제하기
+    @DeleteMapping("/{targetId}")
+    public SuccessResponse<String> deleteTarget(
+            @AuthenticationPrincipal MemberPrincipal memberPrincipal,
+            @PathVariable Long targetId) throws JsonProcessingException {
+
+        // Service 호출
+        targetService.deleteTarget(memberPrincipal.getMemberId(), targetId, memberPrincipal.getUserKey());
+
+        return SuccessResponse.ok("목표가 성공적으로 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/fav/daengnyang/domain/target/service/TargetService.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/TargetService.java
@@ -1,11 +1,16 @@
 package com.fav.daengnyang.domain.target.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fav.daengnyang.domain.account.entity.Account;
 import com.fav.daengnyang.domain.account.repository.AccountRepository;
+import com.fav.daengnyang.domain.member.entity.Member;
+import com.fav.daengnyang.domain.member.repository.MemberRepository;
 import com.fav.daengnyang.domain.target.entity.Target;
 import com.fav.daengnyang.domain.target.repository.TargetRepository;
 import com.fav.daengnyang.domain.target.service.dto.request.CreateTargetRequest;
 import com.fav.daengnyang.domain.target.service.dto.response.TargetResponse;
+import com.fav.daengnyang.domain.targetDetail.entity.TargetDetail;
+import com.fav.daengnyang.domain.targetDetail.repository.TargetDetailRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +23,10 @@ import java.util.List;
 public class TargetService {
 
     private final TargetRepository targetRepository;
+    private final TargetDetailRepository targetDetailRepository;
+    private final MemberRepository memberRepository;
     private final AccountRepository accountRepository;
+    private final TargetTransferService targetTransferService; // 계좌이체 금융 API를 사용하기 위한 TargetTransferService 주입
 
     // 목표 생성 메소드
     @Transactional
@@ -62,5 +70,35 @@ public class TargetService {
                         .accountId(target.getAccount().getAccountId()) // Account ID 반환
                         .build())
                 .toList();
+    }
+
+    // 목표 삭제 메소드
+    public void deleteTarget(Long memberId, Long targetId, String userKey) throws JsonProcessingException {
+        // Target 조회
+        Target target = targetRepository.findById(targetId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 목표를 찾을 수 없습니다."));
+
+        // TargetDetail 리스트 조회 및 amount 합산
+        List<TargetDetail> targetDetails = targetDetailRepository.findByTarget(target);
+        int totalAmount = targetDetails.stream().mapToInt(TargetDetail::getAmount).sum();
+
+        // TargetDetail 삭제
+        targetDetailRepository.deleteAll(targetDetails);
+
+        // Member 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 멤버를 찾을 수 없습니다."));
+
+        // 출금 계좌 (Target의 Bankbook)와 입금 계좌 (Member의 depositAccount) 정보 추출
+        String withdrawalAccountNo = target.getAccount().getAccountNumber();
+        String depositAccountNo = member.getDepositAccount();
+
+        // 총 합계금액을 Member의 depositAccount로 이체
+        if (totalAmount > 0) {
+            targetTransferService.callTransferApi(depositAccountNo, withdrawalAccountNo, totalAmount, userKey); // 재사용
+        }
+
+        // Target 삭제
+        targetRepository.delete(target);
     }
 }

--- a/src/main/java/com/fav/daengnyang/domain/target/service/TargetService.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/TargetService.java
@@ -75,6 +75,7 @@ public class TargetService {
     }
 
 
+    // 목표에 대한 세부정보(입금내역) 조회
     public List<TargetDetailResponse> getTargetDetails(Long targetId) {
         // Target 조회
         Target target = targetRepository.findById(targetId)
@@ -91,11 +92,16 @@ public class TargetService {
                         .createdDate(detail.getCreatedDate())
                         .build())
                 .collect(Collectors.toList());
-}
+    }
 
-// 목표 삭제 메소드
+    // 목표 삭제 메소드
+    @Transactional
     public void deleteTarget(Long memberId, Long targetId, String userKey) throws JsonProcessingException {
-      
+
+        // Target 조회
+        Target target = targetRepository.findById(targetId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 목표를 찾을 수 없습니다."));
+
         // TargetDetail 리스트 조회 및 amount 합산
         List<TargetDetail> targetDetails = targetDetailRepository.findByTarget(target);
         int totalAmount = targetDetails.stream().mapToInt(TargetDetail::getAmount).sum();

--- a/src/main/java/com/fav/daengnyang/domain/target/service/TargetTransferService.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/TargetTransferService.java
@@ -74,7 +74,7 @@ public class TargetTransferService {
     }
 
     // 계좌이체 금융 API
-    private void callTransferApi(String depositAccountNo, String withdrawalAccountNo, int amount, String userKey) throws JsonProcessingException {
+    void callTransferApi(String depositAccountNo, String withdrawalAccountNo, int amount, String userKey) throws JsonProcessingException {
         LocalDateTime now = LocalDateTime.now();
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
         DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HHmmss");

--- a/src/main/java/com/fav/daengnyang/domain/targetDetail/repository/TargetDetailRepository.java
+++ b/src/main/java/com/fav/daengnyang/domain/targetDetail/repository/TargetDetailRepository.java
@@ -1,5 +1,6 @@
 package com.fav.daengnyang.domain.targetDetail.repository;
 
+import com.fav.daengnyang.domain.target.entity.Target;
 import com.fav.daengnyang.domain.targetDetail.entity.TargetDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -20,4 +21,6 @@ public interface TargetDetailRepository extends JpaRepository<TargetDetail, Long
     // 특정 memberId에 해당하는 모든 TargetDetail 조회
     @Query("SELECT td FROM TargetDetail td JOIN td.target t JOIN t.account a WHERE a.member.memberId = :memberId")
     List<TargetDetail> findByMemberId(@Param("memberId") Long memberId);
+
+    List<TargetDetail> findByTarget(Target target);
 }


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #68 

### 📝 작업 내용
- 동작 과정
- 목표 ID를 받아서
- 해당 목표에 대한 모든 TargetDetail들의 Amount 를 다 더해놓음
    - 해당 과정에서 TargetDetail들 삭제
- 투자 계좌 -> 입출금 계좌로 Amount의 총합만큼 보내는 계좌이체 API 호출
- 해당 목표 삭제

### 📝 남은 작업
- 
