### PR TITLE
[FIX] 출금 시 더 이상 목표를 조회할 때 나오지 않도록 수정

### DIFF
--- a/src/main/java/com/fav/daengnyang/domain/target/entity/Target.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/entity/Target.java
@@ -33,6 +33,9 @@ public class Target {
     @Column(name = "is_done")
     private Boolean isDone;
 
+    @Column(name = "is_withdrawed")
+    private Boolean isWithdrawed;
+
     @Column(name = "start_date")
     private LocalDate startDate;
 
@@ -44,12 +47,13 @@ public class Target {
     private Account account;
 
     @Builder
-    public Target(String description, Integer targetAmount, String targetTitle, Integer currentAmount, Boolean isDone, LocalDate startDate, LocalDate endDate, Account account) {
+    public Target(String description, Integer targetAmount, String targetTitle, Integer currentAmount, Boolean isDone, Boolean isWithdrawed, LocalDate startDate, LocalDate endDate, Account account) {
         this.description = description;
         this.targetAmount = targetAmount;
         this.targetTitle = targetTitle;
         this.currentAmount = currentAmount;
         this.isDone = isDone;
+        this.isWithdrawed = isWithdrawed;
         this.startDate = startDate;
         this.endDate = endDate;
         this.account = account;
@@ -57,5 +61,9 @@ public class Target {
 
     public Boolean isDone() {
         return isDone;
+    }
+
+    public Boolean isWithdrawed() {
+        return isWithdrawed;
     }
 }

--- a/src/main/java/com/fav/daengnyang/domain/target/service/TargetService.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/TargetService.java
@@ -58,8 +58,13 @@ public class TargetService {
         // memberId로 Target 리스트 조회
         List<Target> targets = targetRepository.findAllByMemberId(memberId);
 
+        // Target 리스트들 중에서 isWithdrawed가 false인 목표들만 필터링
+        List<Target> activeTargets = targets.stream()
+                .filter(target -> !target.isWithdrawed())
+                .collect(Collectors.toList());
+
         // Target 리스트를 TargetResponse 리스트로 변환하여 반환
-        return targets.stream()
+        return activeTargets.stream()
                 .map(target -> TargetResponse.builder()
                         .targetId(target.getTargetId())
                         .description(target.getDescription())
@@ -67,6 +72,7 @@ public class TargetService {
                         .targetTitle(target.getTargetTitle())
                         .currentAmount(target.getCurrentAmount())
                         .isDone(target.isDone())
+                        .isWithdraw(target.getIsWithdrawed())
                         .startDate(target.getStartDate())
                         .endDate(target.getEndDate())
                         .accountId(target.getAccount().getAccountId()) // Account ID 반환

--- a/src/main/java/com/fav/daengnyang/domain/target/service/TargetService.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/TargetService.java
@@ -39,6 +39,7 @@ public class TargetService {
                 .targetAmount(request.getTargetAmount())
                 .currentAmount(0)
                 .isDone(false)
+                .isWithdrawed(false)
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
                 .account(account)

--- a/src/main/java/com/fav/daengnyang/domain/target/service/TargetTransferService.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/TargetTransferService.java
@@ -103,6 +103,12 @@ public class TargetTransferService {
         if (totalAmount > 0) {
             callTransferApi(depositAccountNo, withdrawalAccountNo, totalAmount, userKey); // 재사용
         }
+
+        // 출금 처리
+        target.setIsWithdrawed(true);
+
+        // 타겟의 현재 금액 0으로 설정
+        target.setCurrentAmount(0);
     }
 
     // 목표 삭제 메소드

--- a/src/main/java/com/fav/daengnyang/domain/target/service/dto/response/TargetResponse.java
+++ b/src/main/java/com/fav/daengnyang/domain/target/service/dto/response/TargetResponse.java
@@ -18,6 +18,7 @@ public class TargetResponse {
     private String targetTitle;
     private int currentAmount;
     private Boolean isDone;
+    private Boolean isWithdraw;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startDate;
@@ -27,13 +28,14 @@ public class TargetResponse {
     private Long accountId;
 
     @Builder
-    public TargetResponse (Long targetId, String description, int targetAmount, String targetTitle, int currentAmount, Boolean isDone, LocalDate startDate, LocalDate endDate, Long accountId) {
+    public TargetResponse (Long targetId, String description, int targetAmount, String targetTitle, int currentAmount, Boolean isDone, Boolean isWithdraw, LocalDate startDate, LocalDate endDate, Long accountId) {
         this.targetId = targetId;
         this.description = description;
         this.targetAmount = targetAmount;
         this.targetTitle = targetTitle;
         this.currentAmount = currentAmount;
         this.isDone = isDone;
+        this.isWithdraw = isWithdraw;
         this.startDate = startDate;
         this.endDate = endDate;
         this.accountId = accountId;


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #134 

### 📝 작업 내용
- 실행 화면
    - DB에 isWithdrawed(출금 여부) 가 true인 target이 있으면
    - ![image](https://github.com/user-attachments/assets/b2e0f15c-8c7d-4b06-ab06-5dbf9dbfdce1)
    - 유저의 모든 목표를 조회할 때 나오지 않는다.
    - ![image](https://github.com/user-attachments/assets/027f3ea2-c9c4-4936-b53b-23965acd7aa4)
    - 요약 정보 조회할 때는 나온다.
    - ![image](https://github.com/user-attachments/assets/b0eadc93-d0c0-4f11-a7ad-29d0e9da9c31)



